### PR TITLE
feat(ui): file uploads and static analysis workflow

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -1,0 +1,97 @@
+name: 'Static Analysis'
+
+on:
+  workflow_call:
+
+jobs:
+  static-analysis-run:
+    name: 'Static Analysis (fmt, Clippy, Audit, Deny, Udeps, Outdated)'
+    runs-on: ubuntu-latest
+
+    container:
+      image: rust:1.87.0-slim-bullseye
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache cargo registry + target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: "cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}"
+
+      - name: Install extra tooling
+        run: |
+          set -e
+          cargo install --locked cargo-audit
+          cargo install --locked cargo-deny
+          cargo install --locked cargo-outdated
+          cargo install --locked cargo-udeps
+          cargo install --locked cargo-msrv
+          rustup toolchain install nightly
+          rustup component add rustfmt clippy
+          echo "Installed helper tools"
+
+      - name: rustfmt check
+        run: cargo fmt --all -- --check
+        continue-on-error: false
+
+      - name: cargo clippy
+        run: cargo clippy --all-targets --all-features -- -D warnings
+        if: always()
+        continue-on-error: true
+
+      - name: cargo test
+        run: cargo test --all
+        if: always()
+        continue-on-error: true
+
+      - name: cargo audit
+        run: cargo audit
+        if: always()
+        continue-on-error: true
+
+      - name: cargo deny
+        run: cargo deny check --all-features
+        if: always()
+        continue-on-error: true
+
+      - name: cargo udeps
+        run: cargo +nightly udeps --all-targets
+        if: always()
+        continue-on-error: true
+
+      - name: cargo outdated
+        run: cargo outdated --workspace --depth=1
+        if: always()
+        continue-on-error: true
+
+      - name: cargo msrv
+        run: cargo msrv verify
+        if: always()
+        continue-on-error: true
+
+  cargo-normalize:
+    name: 'Cargo Sort (normalize Cargo.toml)'
+    runs-on: ubuntu-latest
+
+    container:
+      image: rust:1.87.0-slim-bullseye
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: "cargo-tools-${{ runner.os }}"
+
+      - name: Install cargo-sort
+        run: cargo install --locked cargo-sort
+
+      - name: Check Cargo.toml order
+        run: cargo sort --workspace --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ashpd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd884d7c72877a94102c3715f3b1cd09ff4fac28221add3e57cfbe25c236d093"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +316,17 @@ dependencies = [
  "event-listener",
  "event-listener-strategy",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
 ]
 
 [[package]]
@@ -1083,6 +1112,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1809,6 +1847,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-foundation"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1add1b659e36c9607c7aab864a76c7a4c2760cd0cd2e120f3fb8b952c7e22bf9"
+dependencies = [
+ "block",
+ "objc",
+ "objc_id",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2080,6 +2129,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc_id"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92d4ddb4bd7b50d730c215ff871754d0da6b2178849f8a2a2ab69712d0c073b"
+dependencies = [
+ "objc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2239,6 +2297,12 @@ dependencies = [
  "tracing",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "pollster"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
 name = "potential_utf"
@@ -2406,11 +2470,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
+name = "rfd"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25a73a7337fc24366edfca76ec521f51877b114e42dab584008209cca6719251"
+dependencies = [
+ "ashpd",
+ "block",
+ "dispatch",
+ "js-sys",
+ "log",
+ "objc",
+ "objc-foundation",
+ "objc_id",
+ "pollster",
+ "raw-window-handle",
+ "urlencoding",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "rust-regex-gui"
 version = "0.1.0"
 dependencies = [
  "eframe",
  "regex",
+ "rfd",
 ]
 
 [[package]]
@@ -2915,7 +3003,14 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8_iter"
@@ -3382,6 +3477,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4000,6 +4104,7 @@ dependencies = [
  "enumflags2",
  "serde",
  "static_assertions",
+ "url",
  "zvariant_derive",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2024"
 [dependencies]
 eframe = "0.31"
 regex = "1"
+rfd = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,41 @@
+use regex::Regex;
+
+#[derive(Debug, Clone)]
+pub struct Rule {
+    pattern: Regex,
+    to: String,
+}
+
+impl Rule {
+    pub fn new(pattern: &str, to: impl Into<String>) -> Result<Self, regex::Error> {
+        Ok(Self {
+            pattern: Regex::new(pattern)?,
+            to: to.into(),
+        })
+    }
+
+    pub fn apply(&self, input: &str) -> Option<String> {
+        if self.pattern.is_match(input) {
+            Some(self.to.clone())
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rule_matches_input() {
+        let rule = Rule::new("^file.*\\.txt$", "dest").unwrap();
+        assert_eq!(rule.apply("file1.txt"), Some("dest".into()));
+    }
+
+    #[test]
+    fn rule_does_not_match() {
+        let rule = Rule::new("^file.*\\.txt$", "dest").unwrap();
+        assert_eq!(rule.apply("other.pdf"), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use eframe::{egui, App, Frame};
+use eframe::{App, Frame, egui};
+use rfd::{FileDialog, MessageDialog, MessageLevel};
 
 #[derive(Default)]
 struct Rule {
@@ -16,7 +17,19 @@ impl App for RegexApp {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut Frame) {
         egui::CentralPanel::default().show(ctx, |ui| {
             ui.heading("Regex Rules");
-            ui.checkbox(&mut self.dry_run, "Dry Run");
+            let response = ui.checkbox(&mut self.dry_run, "Dry Run");
+            if response.clicked() {
+                let msg = if self.dry_run {
+                    "Dry run enabled"
+                } else {
+                    "Dry run disabled"
+                };
+                MessageDialog::new()
+                    .set_level(MessageLevel::Info)
+                    .set_title("Dry Run")
+                    .set_description(msg)
+                    .show();
+            }
             ui.separator();
 
             egui::Grid::new("rules_grid").show(ui, |ui| {
@@ -25,8 +38,22 @@ impl App for RegexApp {
                 ui.end_row();
 
                 for rule in &mut self.rules {
-                    ui.text_edit_singleline(&mut rule.from);
-                    ui.text_edit_singleline(&mut rule.to);
+                    ui.horizontal(|ui| {
+                        if ui.button("Select file").clicked() {
+                            if let Some(path) = FileDialog::new().pick_file() {
+                                rule.from = path.display().to_string();
+                            }
+                        }
+                        ui.label(&rule.from);
+                    });
+                    ui.horizontal(|ui| {
+                        if ui.button("Select destination").clicked() {
+                            if let Some(path) = FileDialog::new().pick_folder() {
+                                rule.to = path.display().to_string();
+                            }
+                        }
+                        ui.label(&rule.to);
+                    });
                     ui.end_row();
                 }
             });


### PR DESCRIPTION
## Summary
- add file upload inputs to the rules UI
- show a native dialog when the dry‑run box is toggled
- implement a small domain `Rule` with tests
- add rfd dependency
- include a static analysis GitHub workflow

## Testing
- `cargo fmt`
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684558b96f38832094ca1172927eba7d