### PR TITLE
Add execution and logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,6 +1774,16 @@ name = "nohash-hasher"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
+dependencies = [
+ "overload",
+ "winapi",
+]
 
 [[package]]
 name = "num-traits"
@@ -2114,6 +2130,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2411,6 +2433,8 @@ version = "0.1.0"
 dependencies = [
  "eframe",
  "regex",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2531,6 +2555,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2757,6 +2790,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+]
+
+[[package]]
 name = "tiff"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2848,6 +2891,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
+dependencies = [
+ "nu-ansi-term",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2922,6 +2991,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,3 +6,5 @@ edition = "2024"
 [dependencies]
 eframe = "0.31"
 regex = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["fmt"] }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Simple desktop app written in Rust using `eframe`/`egui`. It allows adding
 regex rules that map file names to a destination directory. A "Dry Run"
 checkbox toggles whether renames should actually happen.
 
+Logs are captured using the [`tracing`](https://crates.io/crates/tracing)
+ecosystem and displayed in the UI.
+
 ## Running locally
 
 ```

--- a/src/application/mod.rs
+++ b/src/application/mod.rs
@@ -1,0 +1,21 @@
+use std::sync::Arc;
+
+use crate::domain::Rule;
+use crate::telemetry::Logger;
+
+pub struct Renamer {
+    logger: Arc<dyn Logger>,
+}
+
+impl Renamer {
+    pub fn new(logger: Arc<dyn Logger>) -> Self {
+        Self { logger }
+    }
+
+    pub fn execute(&self, rules: &[Rule]) {
+        for rule in rules {
+            self.logger
+                .log(&format!("Mapping '{}' -> '{}'", rule.from, rule.to));
+        }
+    }
+}

--- a/src/domain/mod.rs
+++ b/src/domain/mod.rs
@@ -1,0 +1,13 @@
+pub struct Rule {
+    pub from: String,
+    pub to: String,
+}
+
+impl Default for Rule {
+    fn default() -> Self {
+        Self {
+            from: String::new(),
+            to: String::new(),
+        }
+    }
+}

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -1,0 +1,66 @@
+use std::io::{self, Write};
+use std::sync::{Arc, Mutex};
+
+use tracing::{info, subscriber::set_global_default};
+use tracing_subscriber::{Registry, fmt::MakeWriter, layer::SubscriberExt};
+
+/// Abstraction over logging so application code can remain decoupled from
+/// specific logging frameworks.
+pub trait Logger: Send + Sync {
+    fn log(&self, message: &str);
+}
+
+/// Logger implementation that forwards logs to the [`tracing`] facade.
+pub struct TracingLogger;
+
+impl Logger for TracingLogger {
+    fn log(&self, message: &str) {
+        info!("{message}");
+    }
+}
+
+/// Writer that stores formatted log lines in memory so they can be displayed
+/// in the GUI.
+#[derive(Default, Clone)]
+pub struct MemoryWriter {
+    buffer: Arc<Mutex<Vec<u8>>>,
+}
+
+impl MemoryWriter {
+    pub fn logs(&self) -> Vec<String> {
+        let buf = self.buffer.lock().unwrap();
+        String::from_utf8_lossy(&buf)
+            .lines()
+            .map(|s| s.to_string())
+            .collect()
+    }
+}
+
+impl Write for MemoryWriter {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        self.buffer.lock().unwrap().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl<'a> MakeWriter<'a> for MemoryWriter {
+    type Writer = MemoryWriter;
+
+    fn make_writer(&'a self) -> Self::Writer {
+        self.clone()
+    }
+}
+
+/// Initializes global tracing with an in-memory writer. Returns the writer so
+/// callers can read the collected logs.
+pub fn init_tracing() -> MemoryWriter {
+    let writer = MemoryWriter::default();
+    let layer = tracing_subscriber::fmt::layer().with_writer(writer.clone());
+    let subscriber = Registry::default().with(layer);
+    set_global_default(subscriber).expect("set tracing subscriber");
+    writer
+}


### PR DESCRIPTION
## Summary
- add hexagonal modules for application, domain and telemetry
- add execute button and log output in the GUI
- replace custom logger with `tracing` and capture logs in-memory

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_6845a1a22a6c832083e5c82710b74266