### PR TITLE
Fix logging with info level

### DIFF
--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -21,7 +21,7 @@ pub struct TracingLogger;
 
 impl Logger for TracingLogger {
     fn log(&self, message: &str) {
-        info!("{message}");
+        info!("{}", message);
     }
 }
 


### PR DESCRIPTION
## Summary
- log messages via `info!("{}", message)`

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6845ad6e7fbc8320b96593b8d08020c3