### PR TITLE
Add test for startup logging

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ use application::Renamer;
 use domain::Rule;
 use std::sync::Arc;
 use telemetry::{MemoryWriter, TracingLogger, init_tracing};
+use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 
 struct RegexApp {
@@ -20,6 +21,7 @@ struct RegexApp {
 impl RegexApp {
     fn new() -> Self {
         let log_writer = init_tracing(LevelFilter::INFO);
+        info!("RegexApp started");
         let logger = Arc::new(TracingLogger);
         let renamer = Renamer::new(logger);
         Self {
@@ -76,4 +78,15 @@ fn main() -> eframe::Result<()> {
         native_options,
         Box::new(|_cc| Ok(Box::new(RegexApp::new()))),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn logs_are_not_empty_on_start() {
+        let app = RegexApp::new();
+        assert!(!app.log_writer.logs().is_empty());
+    }
 }

--- a/src/telemetry/mod.rs
+++ b/src/telemetry/mod.rs
@@ -64,7 +64,7 @@ pub fn init_tracing(level: LevelFilter) -> MemoryWriter {
     let layer = tracing_subscriber::fmt::layer().with_writer(writer.clone());
     let filter = EnvFilter::new(format!(
         "{}={}",
-        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_NAME").replace('-', "_"),
         level.to_string().to_lowercase()
     ));
     let subscriber = Registry::default().with(filter).with(layer);


### PR DESCRIPTION
## Summary
- ensure filter uses crate name with underscores
- log startup message in RegexApp
- verify logs on startup aren't empty

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6845b95636308320a77efcf232d80df1