### PR TITLE
Add techdocs site content

### DIFF
--- a/docs/techdocs/docs/architecture.md
+++ b/docs/techdocs/docs/architecture.md
@@ -1,0 +1,14 @@
+# Architecture
+
+Regex GUI follows a simple hexagonal architecture inspired by the works of Kent Beck, Robert C. Martin, Sam Newman and Eric Evans. The main layers are:
+
+- **Domain**: core business types and logic (e.g. `Rule`).
+- **Application**: orchestrates use cases (`Renamer`).
+- **Infrastructure/UI**: user interface and external concerns (e.g. telemetry).
+
+```mermaid
+%%{init: {'theme':'base'}}%%
+%% include the external mermaid file
+```
+
+![Architecture](diagrams/architecture.mmd)

--- a/docs/techdocs/docs/development.md
+++ b/docs/techdocs/docs/development.md
@@ -1,0 +1,11 @@
+# Development
+
+This project uses a simple Makefile to streamline common tasks. Useful targets include:
+
+- `make run` – run the application.
+- `make fmt` – format the code base using `cargo fmt`.
+- `make clippy` – run `cargo clippy` with warnings as errors.
+- `make test` – execute unit tests.
+- `make docs` – serve the documentation locally via MkDocs.
+
+The source code adheres to conventional commits and is organized with hexagonal architecture principles.

--- a/docs/techdocs/docs/diagrams/architecture.mmd
+++ b/docs/techdocs/docs/diagrams/architecture.mmd
@@ -1,0 +1,15 @@
+graph TD
+    subgraph Application
+        Renamer
+    end
+    subgraph Domain
+        Rule
+    end
+    subgraph Infrastructure
+        UI
+        Telemetry
+    end
+
+    UI --> Renamer
+    Renamer --> Rule
+    Renamer --> Telemetry

--- a/docs/techdocs/docs/index.md
+++ b/docs/techdocs/docs/index.md
@@ -1,0 +1,5 @@
+# Regex GUI
+
+Regex GUI is a small desktop and web application for renaming files using regular expressions. It is written in Rust and built on top of [`eframe`/`egui`](https://github.com/emilk/egui).
+
+This documentation is served via [MkDocs](https://www.mkdocs.org/) and Backstage TechDocs. Use the navigation on the left to explore the different sections.

--- a/docs/techdocs/docs/usage.md
+++ b/docs/techdocs/docs/usage.md
@@ -1,0 +1,34 @@
+# Usage
+
+## Running locally
+
+```bash
+cargo run
+```
+
+## Docker
+
+Build and run the application using Docker:
+
+```bash
+docker compose up --build
+```
+
+An X11 server must be available on the host as the container forwards the UI.
+
+## Web
+
+To build and run in a browser:
+
+```bash
+rustup target add wasm32-unknown-unknown
+trunk serve
+```
+
+Or use Docker:
+
+```bash
+docker compose up web --build
+```
+
+Then open <http://localhost:8080> in your browser.

--- a/docs/techdocs/mkdocs.yml
+++ b/docs/techdocs/mkdocs.yml
@@ -6,6 +6,9 @@ theme:
 
 nav:
   - Home: index.md
+  - Architecture: architecture.md
+  - Usage: usage.md
+  - Development: development.md
 
 # https://www.mkdocs.org/user-guide/configuration
 plugins:


### PR DESCRIPTION
## Summary
- document Regex GUI with Backstage TechDocs
- outline architecture
- note common development tasks
- add usage instructions
- show hexagonal design as a mermaid diagram

## Testing
- `cargo fmt -- --check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846ea45eaac8320a8916b18843d43e0