### PR TITLE
feat(ui): catppuccin resizable log panel

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use eframe::{App, Frame, egui};
-use egui::{CentralPanel, Margin, RichText};
+use egui::{CentralPanel, Margin, RichText, TopBottomPanel};
 
 #[cfg(target_arch = "wasm32")]
 use console_error_panic_hook;
@@ -13,11 +13,13 @@ use wasm_bindgen_futures::spawn_local;
 mod application;
 mod domain;
 mod telemetry;
+mod theme;
 
 use application::Renamer;
 use domain::Rule;
 use std::sync::Arc;
 use telemetry::{MemoryWriter, TracingLogger, init_tracing};
+use theme::catppuccin_visuals;
 use tracing::info;
 use tracing_subscriber::filter::LevelFilter;
 
@@ -57,6 +59,7 @@ impl App for RegexApp {
             style.spacing.item_spacing = egui::vec2(10.0, 8.0);
             style
         });
+        ctx.set_visuals(catppuccin_visuals());
 
         // --- main UI -------------------------------------------------------
         CentralPanel::default()
@@ -92,12 +95,15 @@ impl App for RegexApp {
                         self.renamer.execute(&self.rules);
                     }
                 });
+            });
 
-                // log view -------------------------------------------------
-                ui.separator();
+        TopBottomPanel::bottom("log_panel")
+            .resizable(true)
+            .default_height(200.0)
+            .show(ctx, |ui| {
                 ui.heading("Logs");
                 egui::ScrollArea::vertical()
-                    .max_height(200.0)
+                    .stick_to_bottom(true)
                     .show(ui, |ui| {
                         for line in self.log_writer.logs() {
                             ui.monospace(line);

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,27 @@
+use eframe::egui::{Color32, Visuals};
+
+/// Catppuccin Mocha inspired visuals.
+pub fn catppuccin_visuals() -> Visuals {
+    let mut v = Visuals::dark();
+    // palette based on https://github.com/catppuccin/palette
+    v.override_text_color = Some(Color32::from_rgb(205, 214, 244));
+    v.widgets.noninteractive.bg_fill = Color32::from_rgb(30, 30, 46); // base
+    v.widgets.inactive.bg_fill = Color32::from_rgb(49, 50, 68); // surface0
+    v.widgets.hovered.bg_fill = Color32::from_rgb(69, 71, 90); // surface1
+    v.widgets.active.bg_fill = Color32::from_rgb(88, 91, 112); // surface2
+    v.selection.bg_fill = Color32::from_rgb(180, 190, 254); // lavender
+    v.hyperlink_color = Color32::from_rgb(180, 190, 254);
+    v.code_bg_color = Color32::from_rgb(49, 50, 68);
+    v
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_lavender_selection() {
+        let visuals = catppuccin_visuals();
+        assert_eq!(visuals.selection.bg_fill, Color32::from_rgb(180, 190, 254));
+    }
+}


### PR DESCRIPTION
### Added
- Catppuccin Mocha inspired visuals
- Bottom log panel with 200 px default height and drag handle

### Changed
- Logs moved to resizable bottom panel


------
https://chatgpt.com/codex/tasks/task_e_6847023fbbf883209f3df7cc66dc54b0