### PR TITLE
Improve regex rule input UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Regex GUI
 Simple desktop app written in Rust using `eframe`/`egui`. It allows adding
 regex rules that map file names to a destination directory. A "Dry Run"
-checkbox toggles whether renames should actually happen.
+checkbox toggles whether renames should actually happen. The rules table offers
+buttons to add or remove entries and the inputs are sized for comfortable
+editing.
 
 Logs are captured using the [`tracing`](https://crates.io/crates/tracing)
 ecosystem and displayed in the UI. The global subscriber filters logs for this

--- a/docs/techdocs/docs/usage.md
+++ b/docs/techdocs/docs/usage.md
@@ -1,5 +1,9 @@
 # Usage
 
+The application displays a table of renaming rules. Each row lets you enter a
+regular expression and the destination path. Rules can be added or removed with
+dedicated buttons and the input fields have ample width for comfortable typing.
+
 ## Running locally
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,28 @@ impl RegexApp {
             log_writer,
         }
     }
+
+    #[cfg(test)]
+    fn new_for_tests() -> Self {
+        let logger = Arc::new(TracingLogger);
+        let renamer = Renamer::new(logger);
+        Self {
+            dry_run: false,
+            rules: vec![Rule::default()],
+            renamer,
+            log_writer: MemoryWriter::default(),
+        }
+    }
+
+    pub fn add_rule(&mut self) {
+        self.rules.push(Rule::default());
+    }
+
+    pub fn remove_rule(&mut self, index: usize) {
+        if index < self.rules.len() {
+            self.rules.remove(index);
+        }
+    }
 }
 
 impl Default for RegexApp {
@@ -68,8 +90,10 @@ impl App for RegexApp {
             .frame(egui::Frame::NONE.inner_margin(Margin::same(16)))
             .show(ctx, |ui| {
                 // title ----------------------------------------------------
-                ui.heading(RichText::new("🔧  Regex Renamer").size(24.0).strong());
-                ui.add_space(4.0);
+                ui.vertical_centered(|ui| {
+                    ui.heading(RichText::new("🔧  Regex Renamer").size(24.0).strong());
+                });
+                ui.add_space(8.0);
                 let changed = ui
                     .checkbox(&mut self.dry_run, "Dry‑run (no files are actually renamed)")
                     .changed();
@@ -80,22 +104,44 @@ impl App for RegexApp {
 
                 // rules table ---------------------------------------------
                 ui.heading("Rules");
-                egui::Grid::new("rules_grid").striped(true).show(ui, |ui| {
-                    ui.label(RichText::new("From Regex").strong());
-                    ui.label(RichText::new("To Path").strong());
-                    ui.end_row();
+                egui::ScrollArea::vertical()
+                    .max_height(200.0)
+                    .show(ui, |ui| {
+                        egui::Grid::new("rules_grid").striped(true).show(ui, |ui| {
+                            ui.label(RichText::new("From Regex").strong());
+                            ui.label(RichText::new("To Path").strong());
+                            ui.label("");
+                            ui.end_row();
 
-                    for rule in &mut self.rules {
-                        ui.text_edit_singleline(&mut rule.from);
-                        ui.text_edit_singleline(&mut rule.to);
-                        ui.end_row();
-                    }
-                });
+                            let regex_width = 240.0;
+                            let path_width = 240.0;
+
+                            let mut index = 0usize;
+                            while index < self.rules.len() {
+                                let rule = &mut self.rules[index];
+                                ui.add_sized(
+                                    [regex_width, 0.0],
+                                    egui::TextEdit::singleline(&mut rule.from).hint_text("regex"),
+                                );
+                                ui.add_sized(
+                                    [path_width, 0.0],
+                                    egui::TextEdit::singleline(&mut rule.to)
+                                        .hint_text("destination"),
+                                );
+                                if ui.button("❌").on_hover_text("Remove rule").clicked() {
+                                    self.remove_rule(index);
+                                    continue;
+                                }
+                                ui.end_row();
+                                index += 1;
+                            }
+                        });
+                    });
 
                 ui.add_space(8.0);
                 ui.horizontal(|ui| {
                     if ui.button("➕  Add rule").clicked() {
-                        self.rules.push(Rule::default());
+                        self.add_rule();
                         info!("Added new rule");
                     }
                     if ui.button("▶  Execute").clicked() {
@@ -165,4 +211,29 @@ fn main() {
             .await
             .expect("failed to start eframe");
     });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn add_rule_appends_default_rule() {
+        let mut app = RegexApp::new_for_tests();
+        let initial_len = app.rules.len();
+        app.add_rule();
+        assert_eq!(app.rules.len(), initial_len + 1);
+        let rule = app.rules.last().unwrap();
+        assert!(rule.from.is_empty() && rule.to.is_empty());
+    }
+
+    #[test]
+    fn remove_rule_deletes_correct_index() {
+        let mut app = RegexApp::new_for_tests();
+        app.add_rule();
+        let second = app.rules[1].from.clone();
+        app.remove_rule(0);
+        assert_eq!(app.rules.len(), 1);
+        assert_eq!(app.rules[0].from, second);
+    }
 }


### PR DESCRIPTION
## Summary
- enhance rule input layout and add delete support
- document the new UI improvements

## Testing
- `make fmt`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_6847206f9e8c8320a39828c5d994f886