### PR TITLE
fix(ui): restrict log toggle to dev mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [Unreleased]
+
+### Changed
+- log panel toggling is restricted to debug builds and no longer covers the action buttons
+
 ## [1.0.1](https://github.com/webgrip/rust-regex-gui/compare/v1.0.0...v1.0.1) (2025-06-09)
 
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Logs are captured using the [`tracing`](https://crates.io/crates/tracing)
 ecosystem and displayed in the UI. The global subscriber filters logs for this
 crate at the `INFO` level so that only relevant messages appear.
 
+When running a debug build you can press **L** to toggle the log panel. In
+release builds the logs remain visible at all times.
+
 ## Running locally
 
 ```

--- a/docs/techdocs/docs/usage.md
+++ b/docs/techdocs/docs/usage.md
@@ -5,6 +5,9 @@ enter a regular expression and the destination path. Dedicated buttons allow you
 to add or remove rows and the input fields have ample width for comfortable
 typing.
 
+When running a debug build, press **L** to hide or show the log panel. In release
+builds the logs are always visible.
+
 ## Running locally
 
 ```bash


### PR DESCRIPTION
## [Unreleased]
### Changed
- log panel toggling is restricted to debug builds and no longer covers the action buttons


------
https://chatgpt.com/codex/tasks/task_e_6847bf9ce4a4832081068c4c29274dc8